### PR TITLE
Cleanup CSRF Token Handling

### DIFF
--- a/server/__tests__/app/api/courses.jest.js
+++ b/server/__tests__/app/api/courses.jest.js
@@ -32,8 +32,7 @@ describe('/courses endpoints', () => {
             sub: user.id
         })
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-        userCookies = [`_myclassroom_session=${userToken}`]
+        userCookies = [`_myclassroom_session=${userToken}`, `xsrf-token=${userSession.csrfToken}`]
         
 
         user2 = await db.User.create({
@@ -46,8 +45,7 @@ describe('/courses endpoints', () => {
             sub: user2.id
         })
         const user2Session = await generateUserSession(user2)
-        user2XsrfCookie = user2Session.csrfToken
-        user2Cookies = [`_myclassroom_session=${user2Token}`]
+        user2Cookies = [`_myclassroom_session=${user2Token}`, `xsrf-token=${user2Session.csrfToken}`]
 
         course2 = await db.Course.create({
             name: "TestingTest 123",
@@ -68,7 +66,7 @@ describe('/courses endpoints', () => {
             name: "Litness 101",
             description: "Wanna get lit? We'll show you how",
             published: false
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.course.name).toEqual("Litness 101")
         expect(resp.body.course.description).toEqual("Wanna get lit? We'll show you how")
@@ -85,7 +83,7 @@ describe('/courses endpoints', () => {
         const resp = await request(app).post('/courses').send({
             description: "Wanna get lit? We'll show you how",
             published: false
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -93,7 +91,7 @@ describe('/courses endpoints', () => {
 
         const respSection = await request(app).post(`/courses/${course.id}/sections`).send({
             number: 15
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(respSection.statusCode).toEqual(201)
         expect(respSection.body.section.courseId).toEqual(course.id)
         expect(respSection.body.section.number).toEqual(15)
@@ -105,7 +103,7 @@ describe('/courses endpoints', () => {
 
         const respSection = await request(app).post(`/courses/${course.id}/sections`).send({
             number: 25
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(respSection.statusCode).toEqual(201)
         expect(respSection.body.section.courseId).toEqual(course.id)
         expect(respSection.body.section.number).toEqual(25)
@@ -117,7 +115,7 @@ describe('/courses endpoints', () => {
 
         const respSection = await request(app).post(`/courses/${course.id}/sections`).send({
             number: 35
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(respSection.statusCode).toEqual(201)
         expect(respSection.body.section.courseId).toEqual(course.id)
         expect(respSection.body.section.number).toEqual(35)
@@ -129,13 +127,13 @@ describe('/courses endpoints', () => {
 
         const respSection = await request(app).post(`/courses/${course.id}/sections`).send({
             number: 20
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(respSection.statusCode).toEqual(403)
     })
 
     it('should respond with 400 for malformed request when there is no section number', async () => {
         const respSection = await request(app).post(`/courses/${course.id}/sections`).send({
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(respSection.statusCode).toEqual(400)
     })
 
@@ -143,7 +141,7 @@ describe('/courses endpoints', () => {
         
         const resp = await request(app).post('/courses/join').send({
             joinCode: section.joinCode
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.section.courseId).toEqual(course.id)
         expect(resp.body.section.number).toEqual(section.number)
@@ -158,7 +156,7 @@ describe('/courses endpoints', () => {
         
         const resp = await request(app).post('/courses/join').send({
             joinCode: section2.joinCode
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.section.courseId).toEqual(course.id)
         expect(resp.body.section.number).toEqual(section2.number)
@@ -173,13 +171,13 @@ describe('/courses endpoints', () => {
         
         const resp = await request(app).post('/courses/join').send({
             joinCode: "XXXXXX"
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(404)
     })
 
     it('should respond with 200 and the teacher courses enrolled in', async () => {
         
-        const resp = await request(app).get('/courses').set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get('/courses').set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.teacherCourses[1].id).toEqual(course.id)
         expect(resp.body.teacherCourses[1].name).toEqual("Litness 101")
@@ -188,7 +186,7 @@ describe('/courses endpoints', () => {
 
     it('should respond with 200 and the student courses enrolled in', async () => {
 
-        const respStudent = await request(app).get('/courses').set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        const respStudent = await request(app).get('/courses').set('Cookie', user2Cookies)
         expect(respStudent.statusCode).toEqual(200)
         expect(respStudent.body.studentCourses[0].id).toEqual(course.id)
         expect(respStudent.body.studentCourses[0].name).toEqual("Litness 101")
@@ -198,7 +196,7 @@ describe('/courses endpoints', () => {
     })
 
     it('should respond with 401 if authorization is wrong', async () => { 
-        const resp = await request(app).get('/courses').set('Cookie', 'booooooo').set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get('/courses').set('Cookie', 'booooooo')
         expect(resp.statusCode).toEqual(401)
     })
 
@@ -207,18 +205,18 @@ describe('/courses endpoints', () => {
             name: "Willy Wonka and his darn chocolate factory",
             description: "I've got a golden ticket dun dun dun dun dun",
             published: true
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
     it('should respond with 403 when student tries to delete a course', async () => {
-        const resp = await request(app).delete(`/courses/${course.id}`).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        const resp = await request(app).delete(`/courses/${course.id}`).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
     it('should respond with 400 when teacher tries to edit a course without required fields', async () => {
         const resp = await request(app).put(`/courses/${course.id}`).send({
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -227,7 +225,7 @@ describe('/courses endpoints', () => {
             name: "Willy Wonka and his darn chocolate factory",
             description: "I've got a golden ticket dun dun dun dun dun",
             published: true
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.course.name).toEqual("Willy Wonka and his darn chocolate factory")
         expect(resp.body.course.description).toEqual("I've got a golden ticket dun dun dun dun dun")
@@ -237,7 +235,7 @@ describe('/courses endpoints', () => {
     it('should respond with 200 when teacher tries to edit a course with only some fields', async () => {
         const resp = await request(app).put(`/courses/${course.id}`).send({
             description: "This is a description. No, like seriously it is"
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.course.name).toEqual("Willy Wonka and his darn chocolate factory")
         expect(resp.body.course.description).toEqual("This is a description. No, like seriously it is")
@@ -246,7 +244,7 @@ describe('/courses endpoints', () => {
 
     it('should respond with 204 when a teacher tries to delete a course', async () => {
         const courseId = course.id
-        const resp = await request(app).delete(`/courses/${course.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).delete(`/courses/${course.id}`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(204)
         const deletedCourse = await db.Course.findByPk(courseId)
         expect(deletedCourse).toBeFalsy()

--- a/server/__tests__/app/api/grades.jest.js
+++ b/server/__tests__/app/api/grades.jest.js
@@ -57,8 +57,7 @@ describe('/grades endpoints', () => {
             sub: user.id
         })
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-        userCookies = [`_myclassroom_session=${userToken}`]
+        userCookies = [`_myclassroom_session=${userToken}`, `xsrf-token=${userSession.csrfToken}`]
         
 
         user2 = await db.User.create({
@@ -71,8 +70,7 @@ describe('/grades endpoints', () => {
             sub: user2.id
         })
         const user2Session = await generateUserSession(user2)
-        user2XsrfCookie = user2Session.csrfToken
-        user2Cookies = [`_myclassroom_session=${user2Token}`]
+        user2Cookies = [`_myclassroom_session=${user2Token}`, `xsrf-token=${user2Session.csrfToken}`]
 
         user3 = await db.User.create({
             firstName: 'Tester',
@@ -84,8 +82,7 @@ describe('/grades endpoints', () => {
             sub: user3.id
         })
         const user3Session = await generateUserSession(user3)
-        user3XsrfCookie = user3Session.csrfToken
-        user3Cookies = [`_myclassroom_session=${user3Token}`]
+        user3Cookies = [`_myclassroom_session=${user3Token}`, `xsrf-token=${user3Session.csrfToken}`]
 
         user4 = await db.User.create({
             firstName: 'Fourth',
@@ -97,8 +94,7 @@ describe('/grades endpoints', () => {
             sub: user4.id
         })
         const user4Session = await generateUserSession(user4)
-        user4XsrfCookie = user4Session.csrfToken
-        user4Cookies = [`_myclassroom_session=${user4Token}`]
+        user4Cookies = [`_myclassroom_session=${user4Token}`, `xsrf-token=${user4Session.csrfToken}`]
 
         user5 = await db.User.create({
             firstName: 'Fifth',
@@ -110,8 +106,7 @@ describe('/grades endpoints', () => {
             sub: user5.id
         })
         const user5Session = await generateUserSession(user5)
-        user5XsrfCookie = user5Session.csrfToken
-        user5Cookies = [`_myclassroom_session=${user5Token}`]
+        user5Cookies = [`_myclassroom_session=${user5Token}`, `xsrf-token=${user5Session.csrfToken}`]
 
         user6 = await db.User.create({
             firstName: 'Sixth',
@@ -123,8 +118,7 @@ describe('/grades endpoints', () => {
             sub: user6.id
         })
         const user6Session = await generateUserSession(user6)
-        user6XsrfCookie = user6Session.csrfToken
-        user6Cookies = [`_myclassroom_session=${user6Token}`]
+        user6Cookies = [`_myclassroom_session=${user6Token}`, `xsrf-token=${user6Session.csrfToken}`]
 
         course = await db.Course.create({
             name: 'Testing Things 101',
@@ -287,7 +281,7 @@ describe('/grades endpoints', () => {
     })
 
     it('should respond with 200 when a teacher gets grades for students in a section', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body[0].studentName).toEqual(`${user2.firstName} ${user2.lastName}`)
         expect(resp.body[0].studentId).toEqual(user2.id)
@@ -299,7 +293,7 @@ describe('/grades endpoints', () => {
     })
 
     it('should respond with 200 when a student gets their for a section', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body[0].lectureId).toEqual(lecture.id)
         expect(resp.body[0].lectureGrade).toEqual(0.33)
@@ -309,12 +303,12 @@ describe('/grades endpoints', () => {
     })
 
     it('should respond with 403 when a student enrolled in a different section tries to get scores for the section in the URL', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user5Cookies).set('X-XSRF-TOKEN', user5XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user5Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
     it('should respond with 403 when a user not enrolled in the course tries to get grades', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user6Cookies).set('X-XSRF-TOKEN', user6XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/grades`).set('Cookie', user6Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 

--- a/server/__tests__/app/api/lectureForSection.jest.js
+++ b/server/__tests__/app/api/lectureForSection.jest.js
@@ -23,8 +23,7 @@ describe('Test api/lecturesForSection', () => {
             sub: teacher.id
         })
         const teachSession = await generateUserSession(teacher)
-        teachXsrfCookie = teachSession.csrfToken
-        teachCookies = [`_myclassroom_session=${teacherToken}`]
+        teachCookies = [`_myclassroom_session=${teacherToken}`, `xsrf-token=${teachSession.csrfToken}`]
         
         student = await db.User.create({
             firstName: 'John',
@@ -36,8 +35,7 @@ describe('Test api/lecturesForSection', () => {
             sub: student.id
         })
         const studentSession = await generateUserSession(student)
-        studentXsrfCookie = studentSession.csrfToken
-        studentCookies = [`_myclassroom_session=${studentToken}`]
+        studentCookies = [`_myclassroom_session=${studentToken}`, `xsrf-token=${studentSession.csrfToken}`]
 
         course1 = await db.Course.create({
             name: 'Capstone Course',
@@ -77,13 +75,13 @@ describe('Test api/lecturesForSection', () => {
 
     describe('PUT /courses/:course_id/sections/:section_id/lectures/:lecture_id', () => {        
         it('should respond with 403 for updating as a student', async () => {
-            const resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
 
         it('should respond with 404 for updating a section id that does not exist', async () => {
-            const resp = await request(app).put(`/courses/${course1.id}/sections/-1/lectures/${lecture1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/sections/-1/lectures/${lecture1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
@@ -101,7 +99,7 @@ describe('Test api/lecturesForSection', () => {
                 userId: teacher.id
             })
             
-            const resp = await request(app).put(`/courses/${temp_course.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${temp_course.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -113,7 +111,7 @@ describe('Test api/lecturesForSection', () => {
                 description: 'temp qqq',
                 courseId: course1.id
             })            
-            const resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${tempLec.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${tempLec.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -121,7 +119,7 @@ describe('Test api/lecturesForSection', () => {
         it('should respond with 200 for successfully updating published status of lectureForSection', async () => {
             const origPublishedStatus = sec1_lec1.published
 
-            let resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            let resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies)
             expect(resp.statusCode).toEqual(200)
 
             // get the updated relationship and check that the published status is opposite of the original
@@ -129,7 +127,7 @@ describe('Test api/lecturesForSection', () => {
             expect(check_relation.published).toEqual(!origPublishedStatus)
 
             // call again to revert the change
-            resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            resp = await request(app).put(`/courses/${course1.id}/sections/${section1.id}/lectures/${lecture1.id}`).set('Cookie', teachCookies)
             expect(resp.statusCode).toEqual(200)
 
             // ensure status is back to original

--- a/server/__tests__/app/api/lectureSummaries.jest.js
+++ b/server/__tests__/app/api/lectureSummaries.jest.js
@@ -56,8 +56,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user.id
         })
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-        userCookies = [`_myclassroom_session=${userToken}`]
+        userCookies = [`_myclassroom_session=${userToken}`, `xsrf-token=${userSession.csrfToken}`]
         
 
         user2 = await db.User.create({
@@ -70,8 +69,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user2.id
         })
         const user2Session = await generateUserSession(user2)
-        user2XsrfCookie = user2Session.csrfToken
-        user2Cookies = [`_myclassroom_session=${user2Token}`]
+        user2Cookies = [`_myclassroom_session=${user2Token}`, `xsrf-token=${user2Session.csrfToken}`]
 
         user3 = await db.User.create({
             firstName: 'Tester',
@@ -83,8 +81,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user3.id
         })
         const user3Session = await generateUserSession(user3)
-        user3XsrfCookie = user3Session.csrfToken
-        user3Cookies = [`_myclassroom_session=${user3Token}`]
+        user3Cookies = [`_myclassroom_session=${user3Token}`, `xsrf-token=${user3Session.csrfToken}`]
 
         user4 = await db.User.create({
             firstName: 'Fourth',
@@ -96,8 +93,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user4.id
         })
         const user4Session = await generateUserSession(user4)
-        user4XsrfCookie = user4Session.csrfToken
-        user4Cookies = [`_myclassroom_session=${user4Token}`]
+        user4Cookies = [`_myclassroom_session=${user4Token}`, `xsrf-token=${user4Session.csrfToken}`]
 
         user5 = await db.User.create({
             firstName: 'Fifth',
@@ -109,8 +105,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user5.id
         })
         const user5Session = await generateUserSession(user5)
-        user5XsrfCookie = user5Session.csrfToken
-        user5Cookies = [`_myclassroom_session=${user5Token}`]
+        user5Cookies = [`_myclassroom_session=${user5Token}`, `xsrf-token=${user5Session.csrfToken}`]
 
         user6 = await db.User.create({
             firstName: 'Sixth',
@@ -122,8 +117,7 @@ describe('/lectureSummaries endpoints', () => {
             sub: user6.id
         })
         const user6Session = await generateUserSession(user6)
-        user6XsrfCookie = user6Session.csrfToken
-        user6Cookies = [`_myclassroom_session=${user6Token}`]
+        user6Cookies = [`_myclassroom_session=${user6Token}`, `xsrf-token=${user6Session.csrfToken}`]
 
         course = await db.Course.create({
             name: 'Testing Things 101',
@@ -280,7 +274,7 @@ describe('/lectureSummaries endpoints', () => {
     })
 
     it('should respond with 200 when a teacher gets responses to questions from a lecture', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body[0].numberOfResponses).toEqual(3)
         expect(resp.body[0].question.stem).toEqual(question.stem)
@@ -290,7 +284,7 @@ describe('/lectureSummaries endpoints', () => {
     })
 
     it('should respond with 200 when a student gets their responses to questions in a lecture', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body[0].question.stem).toEqual(question.stem)
         expect(resp.body[0].response.score).toEqual(1)
@@ -299,12 +293,12 @@ describe('/lectureSummaries endpoints', () => {
     })
 
     it('should respond with 403 when a student tries to get responses for a section they are not enrolled in', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user5Cookies).set('X-XSRF-TOKEN', user5XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user5Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
     it('should respond with 403 when a user tries to get responses for a course they are not enrolled in', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user5Cookies).set('X-XSRF-TOKEN', user5XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/sections/${section.id}/lectures/${lecture.id}/responses`).set('Cookie', user5Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 

--- a/server/__tests__/app/api/questions.jest.js
+++ b/server/__tests__/app/api/questions.jest.js
@@ -34,8 +34,7 @@ describe('/questions endpoints', () => {
             sub: user.id
         })
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-        userCookies = [`_myclassroom_session=${userToken}`]
+        userCookies = [`_myclassroom_session=${userToken}`, `xsrf-token=${userSession.csrfToken}`]
         
 
         user2 = await db.User.create({
@@ -48,8 +47,7 @@ describe('/questions endpoints', () => {
             sub: user2.id
         })
         const user2Session = await generateUserSession(user2)
-        user2XsrfCookie = user2Session.csrfToken
-        user2Cookies = [`_myclassroom_session=${user2Token}`]
+        user2Cookies = [`_myclassroom_session=${user2Token}`, `xsrf-token=${user2Session.csrfToken}`]
 
         course = await db.Course.create({
             name: 'Testing Things 101',
@@ -177,7 +175,7 @@ describe('/questions endpoints', () => {
     })
 
     it('should respond with 200 when a teacher gets the questions for a course', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions?page=0&perPage=2`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions?page=0&perPage=2`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.questions.length).toEqual(2)
         expect(resp.body.questions[0].courseId).toEqual(course.id)
@@ -196,7 +194,7 @@ describe('/questions endpoints', () => {
 
     // note: pages are indexed like an array, starting at 0
     it('should respond with 200 when a teacher gets page 2 of the questions for a course', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions?page=2&perPage=2`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions?page=2&perPage=2`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.questions.length).toEqual(1)
         expect(resp.body.questions[0].courseId).toEqual(course.id)
@@ -209,7 +207,7 @@ describe('/questions endpoints', () => {
     })
 
     it('should respond with 200 when a teacher gets the questions for a course filtered by a search parameter', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions?search=3&page=0&perPage=2`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions?search=3&page=0&perPage=2`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.questions.length).toEqual(2)
         expect(resp.body.questions[0].courseId).toEqual(course.id)
@@ -225,7 +223,7 @@ describe('/questions endpoints', () => {
     })
 
     it('should respond with 200 when query string parameters are left out and should get first 25 questions by default', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.questions.length).toEqual(5)
         expect(resp.body.links.nextPage).toEqual("")
@@ -233,12 +231,12 @@ describe('/questions endpoints', () => {
     })
 
     it('should respond with 400 when page number is out of bounds', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions?page=3&perPage=2`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions?page=3&perPage=2`).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(400)
     })
 
     it('should respond with 403 when a student tries to get the questions', async () => {
-        const resp = await request(app).get(`/courses/${course.id}/questions?page=0&perPage=2`).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        const resp = await request(app).get(`/courses/${course.id}/questions?page=0&perPage=2`).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
@@ -260,7 +258,7 @@ describe('/questions endpoints', () => {
                 2: true,
                 3: false
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(403)
     })
 
@@ -282,7 +280,7 @@ describe('/questions endpoints', () => {
                 2: true,
                 3: false
             }
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.question.type).toEqual('multiple choice')
         expect(resp.body.question.stem).toEqual('What is 2 + 2?')
@@ -308,7 +306,7 @@ describe('/questions endpoints', () => {
                 2: true,
                 3: false
             }
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -318,7 +316,7 @@ describe('/questions endpoints', () => {
             stem: 'Graph y = mx + b',
             content: { },
             answers: { }
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(400)
     })
 

--- a/server/__tests__/app/api/questionsInLecture.jest.js
+++ b/server/__tests__/app/api/questionsInLecture.jest.js
@@ -25,8 +25,7 @@ describe('Test api/questionsInLecture', () => {
             sub: teacher.id
         })
         const teachSession = await generateUserSession(teacher)
-        teachXsrfCookie = teachSession.csrfToken
-        teachCookies = [`_myclassroom_session=${teacherToken}`]
+        teachCookies = [`_myclassroom_session=${teacherToken}`, `xsrf-token=${teachSession.csrfToken}`]
         
         student = await db.User.create({
             firstName: 'John',
@@ -38,8 +37,7 @@ describe('Test api/questionsInLecture', () => {
             sub: student.id
         })
         const studentSession = await generateUserSession(student)
-        studentXsrfCookie = studentSession.csrfToken
-        studentCookies = [`_myclassroom_session=${studentToken}`]
+        studentCookies = [`_myclassroom_session=${studentToken}`, `xsrf-token=${studentSession.csrfToken}`]
 
         course1 = await db.Course.create({
             name: 'Capstone Course',
@@ -92,7 +90,7 @@ describe('Test api/questionsInLecture', () => {
 
     describe('GET /courses/:course_id/lectures/:lecture_id/questions/:question_id', () => {        
         it('should respond with 403 for getting a question as a student', async () => {
-            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -117,7 +115,7 @@ describe('Test api/questionsInLecture', () => {
             })
 
             // call GET using course1 and lecNotInCourse
-            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -128,7 +126,7 @@ describe('Test api/questionsInLecture', () => {
                 type: "multiple choice",
                 stem: "was this in lecture",
             })            
-            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -151,14 +149,14 @@ describe('Test api/questionsInLecture', () => {
                 published: true
             })
 
-            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
 
         it('should respond with 200 for successfully getting a question', async () => {        
 
-            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(200)
             expect(resp.body.id).toEqual(question1.id)
@@ -174,7 +172,7 @@ describe('Test api/questionsInLecture', () => {
     // note: only different type of test is response 200 (all other validation testing is the same here)
     describe('PUT /courses/:course_id/lectures/:lecture_id/questions/:question_id', () => {        
         it('should respond with 403 for updating a question as a student', async () => {
-            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -199,7 +197,7 @@ describe('Test api/questionsInLecture', () => {
             })
 
             // call GET using course1 and lecNotInCourse
-            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -210,7 +208,7 @@ describe('Test api/questionsInLecture', () => {
                 type: "multiple choice",
                 stem: "was this in lecture",
             })            
-            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -233,7 +231,7 @@ describe('Test api/questionsInLecture', () => {
                 published: true
             })
 
-            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
@@ -241,7 +239,7 @@ describe('Test api/questionsInLecture', () => {
         it('should respond with 200 for successfully updating the published status of a question', async () => {        
             const initialPublishedStatus = q1_lec1.published
             
-            let resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            let resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies)
             expect(resp.statusCode).toEqual(200)
 
             // get from database to see if it was updated
@@ -249,7 +247,7 @@ describe('Test api/questionsInLecture', () => {
             expect(check_relation.published).toEqual(!(initialPublishedStatus)) // should be opposite of initial published status
 
             // call again to ensure the published status goes back to original
-            resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies)
             expect(resp.statusCode).toEqual(200)
 
             check_relation = await db.QuestionInLecture.findByPk(q1_lec1.id)
@@ -259,7 +257,7 @@ describe('Test api/questionsInLecture', () => {
 
     describe('POST /courses/:course_id/lectures/:lecture_id/questions/:question_id', () => {        
         it('should respond with 201 for linking question to lecture', async () => {                    
-            let resp = await request(app).post(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question2.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            let resp = await request(app).post(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question2.id}`).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(201)
             expect(resp.body.questionId).toEqual(question2.id)
@@ -267,7 +265,7 @@ describe('Test api/questionsInLecture', () => {
         })
 
         it('should respond with 403 for linking a question as a student', async () => {
-            let resp = await request(app).post(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question2.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            let resp = await request(app).post(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question2.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -292,7 +290,7 @@ describe('Test api/questionsInLecture', () => {
             })
 
             // call GET using course1 and lecNotInCourse
-            const resp = await request(app).post(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).post(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -309,7 +307,7 @@ describe('Test api/questionsInLecture', () => {
 
             let resp = await request(app).post(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question2.id}`).send({
                 published: true
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(201)
             expect(resp.body.questionId).toEqual(question2.id)
@@ -321,7 +319,7 @@ describe('Test api/questionsInLecture', () => {
     describe('PUT /courses/:course_id/lectures/:lecture_id/questions', () => {   
         it('should respond with 400 if not providing both question IDs in body', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -329,7 +327,7 @@ describe('Test api/questionsInLecture', () => {
         it('should respond with 400 if only providing one question ID in body', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
                 questionIdOne: 1
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -338,7 +336,7 @@ describe('Test api/questionsInLecture', () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
                 questionIdOne: 1,
                 questionIdTwo: 2
-            }).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            }).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -366,7 +364,7 @@ describe('Test api/questionsInLecture', () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions`).send({
                 questionIdOne: 1,
                 questionIdTwo: 2
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -380,7 +378,7 @@ describe('Test api/questionsInLecture', () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
                 questionIdOne: question1.id,    // this question is in lecture1
                 questionIdTwo: qsNotInLec.id    // not in lecture1
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -402,7 +400,7 @@ describe('Test api/questionsInLecture', () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
                 questionIdOne: question1.id,
                 questionIdTwo: qsNotInCourse.id     // not in course1
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
@@ -427,7 +425,7 @@ describe('Test api/questionsInLecture', () => {
             const resp = await request(app).put(`/courses/${course1.id}/lectures/${lecture1.id}/questions`).send({
                 questionIdOne: question1.id,
                 questionIdTwo: tempQ.id
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(200)
 
@@ -442,7 +440,7 @@ describe('Test api/questionsInLecture', () => {
 
     describe('DELETE /courses/:course_id/lectures/:lecture_id/questions/:question_id', () => {   
         it('should respond with 403 for deleting a question as a student', async () => {
-            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -467,7 +465,7 @@ describe('Test api/questionsInLecture', () => {
             })
 
             // call DELETE using course1 and lecNotInCourse
-            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecNotInCourse.id}/questions/${question1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -478,7 +476,7 @@ describe('Test api/questionsInLecture', () => {
                 type: "multiple choice",
                 stem: "was this in lecture",
             })
-            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInLec.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -497,7 +495,7 @@ describe('Test api/questionsInLecture', () => {
                 published: true
             })
 
-            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${qsNotInCourse.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
@@ -507,7 +505,7 @@ describe('Test api/questionsInLecture', () => {
             const preDelete = await db.QuestionInLecture.findByPk(q1_lec1.id)
             expect(preDelete).toBeTruthy()
             
-            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).delete(`/courses/${course1.id}/lectures/${lecture1.id}/questions/${question1.id}`).set('Cookie', teachCookies)
             expect(resp.statusCode).toEqual(204)
 
             // same call as before but now question1 shouldn't be in lecture1

--- a/server/__tests__/app/api/responses.jest.js
+++ b/server/__tests__/app/api/responses.jest.js
@@ -42,8 +42,7 @@ describe('/responses endpoints', () => {
             sub: user.id
         })
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-        userCookies = [`_myclassroom_session=${userToken}`]
+        userCookies = [`_myclassroom_session=${userToken}`, `xsrf-token=${userSession.csrfToken}`]
         
 
         user2 = await db.User.create({
@@ -56,8 +55,7 @@ describe('/responses endpoints', () => {
             sub: user2.id
         })
         const user2Session = await generateUserSession(user2)
-        user2XsrfCookie = user2Session.csrfToken
-        user2Cookies = [`_myclassroom_session=${user2Token}`]
+        user2Cookies = [`_myclassroom_session=${user2Token}`, `xsrf-token=${user2Session.csrfToken}`]
 
         user3 = await db.User.create({
             firstName: 'Tester',
@@ -69,8 +67,7 @@ describe('/responses endpoints', () => {
             sub: user3.id
         })
         const user3Session = await generateUserSession(user3)
-        user3XsrfCookie = user3Session.csrfToken
-        user3Cookies = [`_myclassroom_session=${user3Token}`]
+        user3Cookies = [`_myclassroom_session=${user3Token}`, `xsrf-token=${user3Session.csrfToken}`]
 
         course = await db.Course.create({
             name: 'Testing Things 101',
@@ -199,7 +196,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: false
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -208,13 +205,13 @@ describe('/responses endpoints', () => {
             answers: {
                 0: false
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(400)
     })
 
     it('should respond with 400 when the request has no submission', async () => {
         const resp = await request(app).post(`/courses/${course.id}/lectures/${lecture.id}/questions/${question.id}/responses`).send({
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -226,7 +223,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: false
             }
-        }).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie)
+        }).set('Cookie', userCookies)
         expect(resp.statusCode).toEqual(403)
     })
 
@@ -238,7 +235,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: false
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.response.enrollmentId).toEqual(enrollment2.id)
         expect(resp.body.response.questionInLectureId).toEqual(questionInLecture.id)
@@ -259,7 +256,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: true
             }
-        }).set('Cookie', user3Cookies).set('X-XSRF-TOKEN', user3XsrfCookie)
+        }).set('Cookie', user3Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.response.enrollmentId).toEqual(enrollment3.id)
         expect(resp.body.response.questionInLectureId).toEqual(questionInLecture.id)
@@ -281,7 +278,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: true
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.response.enrollmentId).toEqual(enrollment2.id)
         expect(resp.body.response.questionInLectureId).toEqual(questionInLecture2.id)
@@ -302,7 +299,7 @@ describe('/responses endpoints', () => {
                 2: true,
                 3: true
             }
-        }).set('Cookie', user3Cookies).set('X-XSRF-TOKEN', user3XsrfCookie)
+        }).set('Cookie', user3Cookies)
         expect(resp.statusCode).toEqual(201)
         expect(resp.body.response.enrollmentId).toEqual(enrollment3.id)
         expect(resp.body.response.questionInLectureId).toEqual(questionInLecture2.id)
@@ -325,12 +322,12 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: false
             }
-        }).set('Cookie', user2Cookies).set('X-XSRF-TOKEN', user2XsrfCookie)
+        }).set('Cookie', user2Cookies)
         expect(resp.statusCode).toEqual(404)
     })
 
     it('should respond with 400 when resubmission has no request body', async () => {
-        const resp = await request(app).put(`/courses/${course.id}/lectures/${lecture.id}/questions/${question.id}/responses/${response.id}`).send({}).set('Cookie', user3Cookies).set('X-XSRF-TOKEN', user3XsrfCookie)
+        const resp = await request(app).put(`/courses/${course.id}/lectures/${lecture.id}/questions/${question.id}/responses/${response.id}`).send({}).set('Cookie', user3Cookies)
         expect(resp.statusCode).toEqual(400)
     })
 
@@ -342,7 +339,7 @@ describe('/responses endpoints', () => {
                 2: false,
                 3: false
             }
-        }).set('Cookie', user3Cookies).set('X-XSRF-TOKEN', user3XsrfCookie)
+        }).set('Cookie', user3Cookies)
         expect(resp.statusCode).toEqual(200)
         expect(resp.body.response.enrollmentId).toEqual(enrollment3.id)
         expect(resp.body.response.questionInLectureId).toEqual(questionInLecture.id)

--- a/server/__tests__/app/api/sections.jest.js
+++ b/server/__tests__/app/api/sections.jest.js
@@ -22,8 +22,7 @@ describe('api/sections tests', () => {
             sub: teacher.id
         })
         const teachSession = await generateUserSession(teacher)
-        teachXsrfCookie = teachSession.csrfToken
-        teachCookies = [`_myclassroom_session=${teacherToken}`]
+        teachCookies = [`_myclassroom_session=${teacherToken}`, `xsrf-token=${teachSession.csrfToken}`]
         
         student = await db.User.create({
             firstName: 'John',
@@ -35,8 +34,7 @@ describe('api/sections tests', () => {
             sub: student.id
         })
         const studentSession = await generateUserSession(student)
-        studentXsrfCookie = studentSession.csrfToken
-        studentCookies = [`_myclassroom_session=${studentToken}`]
+        studentCookies = [`_myclassroom_session=${studentToken}`, `xsrf-token=${studentSession.csrfToken}`]
 
         course1 = await db.Course.create({
             name: 'Capstone Course',
@@ -66,14 +64,14 @@ describe('api/sections tests', () => {
         it('should respond with 400 for creating a section with already existing number', async () => {
             const resp = await request(app).post(`/courses/${course1.id}/sections`).send({
                 number: 1
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
 
         it('should respond with 400 for creating a section with missing value', async () => {
             const resp = await request(app).post(`/courses/${course1.id}/sections`).send({
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -81,7 +79,7 @@ describe('api/sections tests', () => {
         it('should respond with 403 for creating a section as a student', async () => {
             const resp = await request(app).post(`/courses/${course1.id}/sections`).send({
                 number: 2
-            }).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            }).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -89,7 +87,7 @@ describe('api/sections tests', () => {
         it('should respond with 201 for successfully creating section', async () => {
             const resp = await request(app).post(`/courses/${course1.id}/sections`).send({
                 number: 2
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(201)
             expect(resp.body.section.courseId).toEqual(course1.id)
@@ -115,13 +113,13 @@ describe('api/sections tests', () => {
         })
     
         it('should respond with 403 for getting sections as a non teacher', async () => {
-            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
 
         it('should respond with 204 for a course with no sections', async () => {
-            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(204)
         })
@@ -133,7 +131,7 @@ describe('api/sections tests', () => {
                 courseId: courseToGetFrom.id
             })
             
-            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${courseToGetFrom.id}/sections`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(200)
             expect(resp.body.length).toEqual(1)
@@ -150,13 +148,13 @@ describe('api/sections tests', () => {
 
     describe('GET /courses/:course_id/sections/:section_id', () => {
         it('should respond with 404 for getting a section with bad section id', async () => {
-            const resp = await request(app).get(`/courses/${course1.id}/sections/${-1}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/sections/${-1}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(404)
         })
 
         it('should respond with 403 for getting a section as a student', async () => {
-            const resp = await request(app).get(`/courses/${course1.id}/sections/${section1.id}`).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/sections/${section1.id}`).set('Cookie', studentCookies)
 
             expect(resp.statusCode).toEqual(403)
         })
@@ -174,7 +172,7 @@ describe('api/sections tests', () => {
                 userId: teacher.id
             })
 
-            const resp = await request(app).get(`/courses/${temp_course.id}/sections/${section1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${temp_course.id}/sections/${section1.id}`).set('Cookie', teachCookies)
 
             expect(resp.statusCode).toEqual(400)
         })
@@ -193,7 +191,7 @@ describe('api/sections tests', () => {
                 sectionId: section1.id,
             })
             
-            const resp = await request(app).get(`/courses/${course1.id}/sections/${section1.id}`).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            const resp = await request(app).get(`/courses/${course1.id}/sections/${section1.id}`).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(200)
             expect(resp.body.section.id).toEqual(section1.id)
@@ -219,7 +217,7 @@ describe('api/sections tests', () => {
         it('should respond with 400 for updating section with conflicting number', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/sections/${sectionToUpdate.id}`).send({
                 number: 1
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)  
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(400)
         })
@@ -227,14 +225,14 @@ describe('api/sections tests', () => {
         it('should respond with 400 for updating section with empty number', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/sections/${sectionToUpdate.id}`).send({
                 number: ""
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)  
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(400)
         })
 
         it('should respond with 400 for updating section with no number', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/sections/${sectionToUpdate.id}`).send({
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)  
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(400)
         })
@@ -242,7 +240,7 @@ describe('api/sections tests', () => {
         it('should respond with 404 for updating section invalid id', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/sections/${-1}`).send({
                 number: 4
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)  
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(404)
         })
@@ -250,7 +248,7 @@ describe('api/sections tests', () => {
         it('should respond with 403 for updating section as a student', async () => {
             const resp = await request(app).put(`/courses/${course1.id}/sections/${sectionToUpdate.id}`).send({
                 number: 4
-            }).set('Cookie', studentCookies).set('X-XSRF-TOKEN', studentXsrfCookie)  
+            }).set('Cookie', studentCookies)
             
             expect(resp.statusCode).toEqual(403)
         })
@@ -270,7 +268,7 @@ describe('api/sections tests', () => {
 
             const resp = await request(app).put(`/courses/${temp_course.id}/sections/${sectionToUpdate.id}`).send({
                 number: 4
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)
+            }).set('Cookie', teachCookies)
             
             expect(resp.statusCode).toEqual(400)
         })
@@ -278,7 +276,7 @@ describe('api/sections tests', () => {
         it('should respond with 200 for successfully updating section', async () => {       
             const resp = await request(app).put(`/courses/${course1.id}/sections/${sectionToUpdate.id}`).send({
                 number: 4
-            }).set('Cookie', teachCookies).set('X-XSRF-TOKEN', teachXsrfCookie)  
+            }).set('Cookie', teachCookies)  
 
             expect(resp.statusCode).toEqual(200)
             

--- a/server/__tests__/app/api/users.jest.js
+++ b/server/__tests__/app/api/users.jest.js
@@ -400,18 +400,15 @@ describe('/users/:userId', () => {
         })
 
         const userSession = await generateUserSession(user)
-        userXsrfCookie = userSession.csrfToken
-
         const adminSession = await generateUserSession(admin)
-        adminXsrfCookie = adminSession.csrfToken
         
-        userCookies = [`_myclassroom_session=${userJwt}`]
-        adminCookies = [`_myclassroom_session=${adminJwt}`]
+        userCookies = [`_myclassroom_session=${userJwt}`, `xsrf-token=${userSession.csrfToken}`]
+        adminCookies = [`_myclassroom_session=${adminJwt}`, `xsrf-token=${adminSession.csrfToken}`]
     })
 
     describe('GET', () => {
         it ('should return 200 and user information for that user', async () => {
-            const resp = await request(app).get(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${user.id}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(200)
             expect(resp.body.user.firstName).toEqual('regular')
             expect(resp.body.user.lastName).toEqual('user')
@@ -419,7 +416,7 @@ describe('/users/:userId', () => {
         })
 
         it ('should return 200 and user information for admin user', async () => {
-            const resp = await request(app).get(`/users/${user.id}`).set('Cookie', adminCookies).set('X-XSRF-TOKEN', adminXsrfCookie).send()
+            const resp = await request(app).get(`/users/${user.id}`).set('Cookie', adminCookies).send()
             expect(resp.statusCode).toEqual(200)
             expect(resp.body.user.firstName).toEqual('regular')
             expect(resp.body.user.lastName).toEqual('user')
@@ -427,14 +424,14 @@ describe('/users/:userId', () => {
         })
 
         it ('should return 403 and insufficient permissions', async () => {
-            const resp = await request(app).get(`/users/${admin.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${admin.id}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(403)
             expect(resp.body.error).toEqual(`Insufficient permissions to access that resource`)
         })
 
         it ('should return 404 and user not found', async () => {
             const fakeId = 123123132
-            const resp = await request(app).get(`/users/${fakeId}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${fakeId}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(404)
             expect(resp.body.error).toEqual(`User with id ${fakeId} not found`)
         })
@@ -443,7 +440,7 @@ describe('/users/:userId', () => {
     describe('PUT', () => {
         it('should respond with 404 and user not found', async () => {
             const fakeId = 123123132
-            const resp = await request(app).put(`/users/${fakeId}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${fakeId}`).set('Cookie', userCookies).send({
                 firstName: 'faker'
             })
             expect(resp.statusCode).toEqual(404)
@@ -451,7 +448,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 403 and insufficient permissions', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', adminCookies).set('X-XSRF-TOKEN', adminXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', adminCookies).send({
                 firstName: 'admintakeover'
             })
             expect(resp.statusCode).toEqual(403)
@@ -459,13 +456,13 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 400 and no fields', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({})
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({})
             expect(resp.statusCode).toEqual(400)
             expect(resp.body.error).toEqual(`Missing any valid fields to update the user: email, firstName, lastName`)
         })
 
         it('should respond with 400 and not empty violation for firstName', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: ""
             })
             expect(resp.statusCode).toEqual(400)
@@ -473,7 +470,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 200 and updated information', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: 'updated',
                 lastName: 'irregular',
                 email: 'irregularuser@myclassroom.com'
@@ -490,7 +487,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 400 and missing fields for password change', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: 'updated',
                 lastName: 'irregular',
                 email: 'irregularuser@myclassroom.com',
@@ -502,7 +499,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 401 and incorrect password', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: 'updated',
                 lastName: 'irregular',
                 email: 'irregularuser@myclassroom.com',
@@ -515,7 +512,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 400 and password mismatch', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: 'updated',
                 lastName: 'irregular',
                 email: 'irregularuser@myclassroom.com',
@@ -528,7 +525,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 200 and updated information and password changed', async () => {
-            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}`).set('Cookie', userCookies).send({
                 firstName: 'updater',
                 lastName: 'irregulars',
                 email: 'irregularsuser@myclassroom.com',
@@ -579,21 +576,20 @@ describe('/users/:userId', () => {
             })
             
             const userSession = await generateUserSession(user)
-            userXsrfCookie = userSession.csrfToken
-            
-            userCookies = [`_myclassroom_session=${userJwt}`]
+            userCookies = [`_myclassroom_session=${userJwt}`, `xsrf-token=${userSession.csrfToken}`]
         })
 
         it('should respond with 404 and user not found', async () => {
-            const resp = await request(app).put(`/users/${12345}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${12345}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: '123456'
             })
+            
             expect(resp.statusCode).toEqual(404)
             expect(resp.body.error).toEqual(`User with id 12345 not found`)
         })
 
         it('should respond with 403 and insufficient permissions', async () => {
-            const resp = await request(app).put(`/users/${admin.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${admin.id}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: '123456'
             })
             expect(resp.statusCode).toEqual(403)
@@ -601,7 +597,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 400 and emailConfirmationCode required', async () => {
-            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).send({
                 garbage: 1
             })
             expect(resp.statusCode).toEqual(400)
@@ -609,7 +605,7 @@ describe('/users/:userId', () => {
         })
 
         it ('should respond with 401 and emailConfirmationCode incorrect', async () => {
-            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: '123456'
             })
             expect(resp.statusCode).toEqual(401)
@@ -619,7 +615,7 @@ describe('/users/:userId', () => {
         it('should respond with 498 and emailConfirmationCode expired and new email send', async () => {
             await user.update({emailConfirmationExpiresAt: moment().utc()})
             expect(user.emailConfirmationExpired()).toEqual(true)
-            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: user.emailConfirmationCode
             })
             expect(resp.statusCode).toEqual(498)
@@ -629,7 +625,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 200', async () => {
-            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: user.emailConfirmationCode
             })
             expect(resp.statusCode).toEqual(200)
@@ -638,7 +634,7 @@ describe('/users/:userId', () => {
         })
 
         it('should respond with 409 and email already confirmed', async () => {
-            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send({
+            const resp = await request(app).put(`/users/${user.id}/confirm`).set('Cookie', userCookies).send({
                 emailConfirmationCode: user.emailConfirmationCode
             })
             expect(resp.statusCode).toEqual(409)
@@ -676,26 +672,24 @@ describe('/users/:userId', () => {
             })
 
             const userSession = await generateUserSession(user)
-            userXsrfCookie = userSession.csrfToken
-            
-            userCookies = [`_myclassroom_session=${userJwt}`]
+            userCookies = [`_myclassroom_session=${userJwt}`, `xsrf-token=${userSession.csrfToken}`]
         })
 
         it('should respond with 404 and user not found', async () => {
-            const resp = await request(app).get(`/users/${12345}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${12345}/confirm`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(404)
             expect(resp.body.error).toEqual(`User with id 12345 not found`)
         })
 
         it('should respond with 403 and insufficient permissions', async () => {
-            const resp = await request(app).get(`/users/${admin.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${admin.id}/confirm`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(403)
             expect(resp.body.error).toEqual(`Insufficient permissions to access that resource`)
         })
 
         it('should respond with 200', async () => {
             const emailConfirmationCode = user.emailConfirmationCode
-            const resp = await request(app).get(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${user.id}/confirm`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(200)
             await user.reload()
             expect(user.emailConfirmationCode).not.toEqual(emailConfirmationCode)
@@ -703,7 +697,7 @@ describe('/users/:userId', () => {
 
         it('should respond with 400 and email already confirmed', async () => {
             await user.update({emailConfirmed: true})
-            const resp = await request(app).get(`/users/${user.id}/confirm`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).get(`/users/${user.id}/confirm`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(400)
             expect(resp.body.error).toEqual(`email already confirmed`)
         })
@@ -744,35 +738,32 @@ describe('/users/:userId', () => {
             })
 
             const userSession = await generateUserSession(user)
-            userXsrfCookie = userSession.csrfToken
-
             const adminSession = await generateUserSession(admin)
-            adminXsrfCookie = adminSession.csrfToken
             
-            userCookies = [`_myclassroom_session=${userJwt}`]
-            adminCookies = [`_myclassroom_session=${adminJwt}`]
+            userCookies = [`_myclassroom_session=${userJwt}`, `xsrf-token=${userSession.csrfToken}`]
+            adminCookies = [`_myclassroom_session=${adminJwt}`, `xsrf-token=${adminSession.csrfToken}`]
         })
 
         it('should respond with 404 and user not found', async () => {
             const fakeId = 123123132
-            const resp = await request(app).delete(`/users/${fakeId}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).delete(`/users/${fakeId}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(404)
             expect(resp.body.error).toEqual(`User with id ${fakeId} not found`)
         })
 
         it('should respond with 403 and insufficient permissions', async () => {
-            const resp = await request(app).delete(`/users/${admin.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).delete(`/users/${admin.id}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(403)
             expect(resp.body.error).toEqual(`Insufficient permissions to access that resource`)
         })
 
         it ('should respond with 204 and admin deleted', async () => {
-            const resp = await request(app).delete(`/users/${admin.id}`).set('Cookie', adminCookies).set('X-XSRF-TOKEN', adminXsrfCookie).send()
+            const resp = await request(app).delete(`/users/${admin.id}`).set('Cookie', adminCookies).send()
             expect(resp.statusCode).toEqual(204)
         })
 
         it ('should respond with 204 and user deleted', async () => {
-            const resp = await request(app).delete(`/users/${user.id}`).set('Cookie', userCookies).set('X-XSRF-TOKEN', userXsrfCookie).send()
+            const resp = await request(app).delete(`/users/${user.id}`).set('Cookie', userCookies).send()
             expect(resp.statusCode).toEqual(204)
         })        
     })

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -65,9 +65,8 @@ const removeUserAuthCookie = async (req, res) => {
  */
 const requireAuthentication = async (req, res, next) => {
     // Extract session/CSRF token from cookies
-    const token = req.cookies["_myclassroom_session"];
-//    const csrfToken = req.headers["x-xsrf-token"];
-    const csrfToken = req.cookies["xsrf-token"];
+    const token = req.cookies["_myclassroom_session"] || req.headers["_myclassroom_session"]; // Prefer cookie over header
+    const csrfToken = req.cookies["xsrf-token"] || req.headers["xsrf-token"]; // Prefer cookie over header
     
     try {
         const payload = jwtUtils.decode(token); // Decode JWT token to get payload

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -1,116 +1,138 @@
-const jwt_utils = require('./jwt_utils')
-const { serialize } = require('cookie')
-const db = require('../app/models')
-const { logger } = require('./logger')
-const moment = require('moment')
+// Import necessary modules using CommonJS syntax
+const jwtUtils = require('./jwt_utils'); // For JWT token operations
+const { serialize } = require('cookie'); // For serializing cookies
+const db = require('../app/models'); // Access to the database models
+const { logger } = require('./logger'); // Logging utility
+const moment = require('moment'); // Date manipulation library
 const string_helpers = require('./string_helpers')
-const { ValidationError } = require('sequelize')
+const { ValidationError } = require('sequelize'); // Sequelize error handling
 
+/**
+ * Generates a JWT token for a user
+ * @param {Object} user - The user object for which to generate the token
+ * @returns {String} - The generated JWT token
+ */
 const generateUserAuthToken = (user) => {
-    const payload = {
-        sub: user.id
-    }
+    const payload = { sub: user.id }; // Payload with user ID
     // TODO: incorporate account locking and other user-model information checking in this method (email confirmation, failed login attempts, etc)
-    return jwt_utils.encode(payload)
-}
+    return jwtUtils.encode(payload); // Encode payload into JWT token
+};
 
+/**
+ * Sets the authentication cookie in the user's browser
+ * @param {Object} res - The response object to set cookie headers on
+ * @param {Object} user - The user object to create a session for
+ */
 const setUserAuthCookie = async (res, user) => {
-    const userSession = await generateUserSession(user)
+    const userSession = await generateUserSession(user); // Generate new user session
+    const expiry = new Date(Date.now() + 1000 * 60 * 60 * 12); // Expire cookie in 12hrs
+    
+    // Set two cookies: one for the session token and another for the CSRF token
     res.setHeader("Set-Cookie", [
         serialize("_myclassroom_session", generateUserAuthToken(user), {
             path: "/",
-            httpOnly: true, //this means that the cookie is only accessible to the server and sent along in reequests. The client side has no direct access to it
-            expires: new Date(Date.now() + 1000 * 60 * 60 * 12) //expires in 12 hours
+            httpOnly: true, // Cookie is HTTP only for security
+            expires: expiry // Set expiry for cookie
         }),
-        serialize("XSRF-TOKEN", userSession.csrfToken, { //protect from CSRF by giving the client a token that can be accessed and attached in request headers for checking
+        serialize("xsrf-token", userSession.csrfToken, {
             path: "/",
-            expires: new Date(Date.now() + 1000 * 60 * 60 * 12) //expires in 12 hours
+            expires: expiry // Set expiry for CSRF token
         })
-    ])
-}
-exports.setUserAuthCookie = setUserAuthCookie
+    ]);
+};
 
+/**
+ * Removes the authentication cookie from the user's browser
+ * @param {Object} req - The request object to read cookies from
+ * @param {Object} res - The response object to set cookie headers on
+ */
 const removeUserAuthCookie = async (req, res) => {
-    await db.Session.update({ expires: moment().utc()}, { where: { csrfToken: extractCsrfToken(req) }})
+    // Update session to expire immediately
+    await db.Session.update({ expires: moment().utc()}, { where: { csrfToken: req.cookies["xsrf-token"]}});
+    
+    // Clear both cookies by setting them to empty strings
     res.setHeader("Set-Cookie", [
-        serialize("_myclassroom_session", "", {
-            path: "/",
-            httpOnly: true
-        }),
-        serialize("XSRF-TOKEN", "", {
-            path: "/"
-        })
-    ])
-}
-exports.removeUserAuthCookie = removeUserAuthCookie
+        serialize("_myclassroom_session", "", { path: "/", httpOnly: true }),
+        serialize("xsrf-token", "", { path: "/" })
+    ]);
+};
 
-async function requireAuthentication(req, res, next) {
-    const token = extractToken(req)
-    const csrfToken = extractCsrfToken(req)
+/**
+ * Middleware to require authentication for a route
+ * @param {Object} req - The request object
+ * @param {Object} res - The response object
+ * @param {Function} next - The next middleware function in the stack
+ */
+const requireAuthentication = async (req, res, next) => {
+    // Extract session/CSRF token from cookies
+    const token = req.cookies["_myclassroom_session"];
+//    const csrfToken = req.headers["x-xsrf-token"];
+    const csrfToken = req.cookies["xsrf-token"];
+    
     try {
-        const payload = jwt_utils.decode(token)
-        const session = await validateCsrfToken(csrfToken, payload.sub)
-        req.payload = payload
-        await session.update({ expires: moment().add(4, 'H').utc() })
-        next()
+        const payload = jwtUtils.decode(token); // Decode JWT token to get payload
+        const session = await validateCsrfToken(csrfToken, payload.sub); // Validate CSRF token
+        req.payload = payload; // Attach payload to request object
+        await session.update({ expires: moment().add(4, 'H').utc() }); // Update session expiry
+        next(); // Proceed to next middleware
     } catch (err) {
-        logger.error(err)
-        res.status(401).send({
-            error: "Invalid authentication token"
-        })
+        logger.error(err);
+        // Respond with a 401 Unauthorized status if authentication fails
+        res.status(401).send({ error: "Invalid authentication token" });
     }
-}
-exports.requireAuthentication = requireAuthentication
+};
 
-const extractToken = (req) => {
-    return req.cookies["_myclassroom_session"]
-}
-exports.extractToken = extractToken
-
-const extractCsrfToken = (req) => {
-    return req.headers["x-xsrf-token"] || req.headers["X-XSRF-TOKEN"]
-}
-
+/**
+ * Validates the CSRF token
+ * @param {String} token - The CSRF token to validate
+ * @param {Number} userId - The user ID to validate the token against
+ * @returns {Object} - The session object if validation is successful
+ */
 const validateCsrfToken = async (token, userId) => {
-    const session = await db.Session.findOne({ where: { csrfToken: token } })
-    if (session == null) {
-        logger.error(`XSRF token unauthenticated, token: ${token}`)
-        throw new Error("csrf token unauthenticated")
-    }
-    else {
-        const expired = session.checkIfExpired()
-        if (expired) {
-            logger.error("User tried to use an expired session")
-            throw new Error("user session expired")
-        }
-        else {
-            if (session.userId != userId) {
-                logger.error(`Authenticated user and user session somehow didn't match, session.userId: ${session.userId}, userId: ${userId}`)
-                throw new Error("user session and login do not match")
-            }
-            return session
-        }
-    }
-}
+    // Get session from XSRF token and userId
+    const session = await db.Session.findOne({ where: { csrfToken: token } });
+    
+    // If session does not exist, fail token
+    if (!session)
+        throw new Error("xsrf token missing");
+    
+    // If session expired, fail token
+    if (session.checkIfExpired())
+        throw new Error("user session expired");
+    
+    // If session userId missmatch, fail token
+    if (session.userId != userId)
+        throw new Error("user/session missmatch");
+    
+    // Otherwise return valid session
+    return session;
+};
 
+/**
+ * Generates a new session for a user
+ * @param {Object} user - The user object to create a session for
+ * @returns {Object} - The created session object
+ */
 const generateUserSession = async (user) => {
     try {
         // TODO: expire the most recent one
-        await db.Session.update({ expires: moment().utc() }, { where: { userId: user.id } })
-        const session = await db.Session.create({
-            userId: user.id
-        })
-        return session
-    }
-    catch (e) {
-        logger.error(`user session creation unexpectedly failed for user: ${user.id}`)
+        await db.Session.update({ expires: moment().utc() }, { where: { userId: user.id } });
+        
+        // Create/return a new session for the user
+        return await db.Session.create({ userId: user.id });
+    } catch (e) {
+        logger.error(`user session creation unexpectedly failed for user: ${user.id}`);
+        
+        // Handle specific Sequelize validation errors
         if (e instanceof ValidationError) {
-            logger.error(string_helpers.serializeSequelizeErrors(e))
+            logger.error(string_helpers.serializeSequelizeErrors(e));
+            throw new Error("Unable to create user session");
         }
-        else {
-            logger.error(e)
-        }
-        throw new Error("Unable to create user session")
+        
+        logger.error(e);
+        throw new Error("Unable to create user session");
     }
-}
-exports.generateUserSession = generateUserSession
+};
+
+// Exporting functions to be used elsewhere in the application
+module.exports = { setUserAuthCookie, removeUserAuthCookie, requireAuthentication, generateUserSession };


### PR DESCRIPTION
Adjusted auth.js to use cookies to get the XSRF token, rather than HTTPS headers. This may be readjusted in the future, but resolves unexpected behavior with XSRF tokens returning incorrectly. Closes #122 

Changes:
- Cleanup/Comment auth.js
- Restructure auth.js to use exclusively cookies, rather than storing token in cookie but selectively returning in header
- Adjust tests to reflect change from header to cookies
- Fix broken test incorrectly giving a valid token when testing for invalid token