### PR TITLE
fix small DOM bug

### DIFF
--- a/client/src/pages/AddCourse.js
+++ b/client/src/pages/AddCourse.js
@@ -88,7 +88,7 @@ function AddCourse(props){
                         size="large" 
                         onChange={(e) => setPublished(e.target.value)}/>
                 </Form.Group>
-                <div class="create-btns">
+                <div className="create-btns">
                     <Link to={`/`}>
                         <Button variant="secondary" id="create-cancel">
                             Cancel


### PR DESCRIPTION
found a small bug:
react-dom.development.js:67 Warning: Invalid DOM property `class`
that was caused by a typo in addCourse